### PR TITLE
Fix dmesh importer error

### DIFF
--- a/haydee_importer/import_dmesh.py
+++ b/haydee_importer/import_dmesh.py
@@ -412,7 +412,7 @@ class ImportHaydeeDMesh(Operator, ImportHelper):
         return {'RUNNING_MODAL'}
 
     def execute(self, context):
-        for filepath in self.files:
-            read_dmesh(self, context, os.path.join(self.directory, filepath),
+        for file in self.files:
+            read_dmesh(self, context, os.path.join(self.directory, file.name),
                        self.file_format)
         return {"FINISHED"}


### PR DESCRIPTION
Fix this error:

```
Python: Traceback (most recent call last):
  File "~/.config/blender/3.5/scripts/addons/HaydeeTools/haydee_importer/import_dmesh.py", line 416, in execute
    read_dmesh(self, context, os.path.join(self.directory, filepath),
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 90, in join
  File "<frozen genericpath>", line 152, in _check_arg_types
TypeError: join() argument must be str, bytes, or os.PathLike object, not 'OperatorFileListElement'

```